### PR TITLE
Add x-checker-data for dependencies & upgrade some Python dependencies

### DIFF
--- a/app.polychromatic.controller.json
+++ b/app.polychromatic.controller.json
@@ -159,8 +159,8 @@
                     "sources": [
                         {
                             "type": "file",
-                            "url": "https://files.pythonhosted.org/packages/91/c0/104cb6244c83fe6bc3886f144cc433db0c0c78efac5dc00e409a5a08c87d/meson_python-0.16.0-py3-none-any.whl",
-                            "sha256": "842dc9f5dc29e55fc769ff1b6fe328412fe6c870220fc321060a1d2d395e69e8",
+                            "url": "https://files.pythonhosted.org/packages/7d/ec/40c0ddd29ef4daa6689a2b9c5ced47d5b58fa54ae149b19e9a97f4979c8c/meson_python-0.17.1-py3-none-any.whl",
+                            "sha256": "30a75c52578ef14aff8392677b09c39346e0a24d2b2c6204b8ed30583c11269c",
                             "x-checker-data": {
                                 "type": "pypi",
                                 "name": "meson_python",
@@ -179,8 +179,8 @@
                         },
                         {
                             "type": "file",
-                            "url": "https://files.pythonhosted.org/packages/aa/5f/bb5970d3d04173b46c9037109f7f05fc8904ff5be073ee49bb6ff00301bc/pyproject_metadata-0.8.0-py3-none-any.whl",
-                            "sha256": "ad858d448e1d3a1fb408ac5bac9ea7743e7a8bbb472f2693aaa334d2db42f526",
+                            "url": "https://files.pythonhosted.org/packages/e8/61/9dd3e68d2b6aa40a5fc678662919be3c3a7bf22cba5a6b4437619b77e156/pyproject_metadata-0.9.0-py3-none-any.whl",
+                            "sha256": "fc862aab066a2e87734333293b0af5845fe8ac6cb69c451a41551001e923be0b",
                             "x-checker-data": {
                                 "type": "pypi",
                                 "name": "pyproject_metadata",

--- a/app.polychromatic.controller.json
+++ b/app.polychromatic.controller.json
@@ -29,7 +29,13 @@
                 {
                     "type": "archive",
                     "url": "https://github.com/sass/sassc/archive/3.6.2.tar.gz",
-                    "sha256": "608dc9002b45a91d11ed59e352469ecc05e4f58fc1259fc9a9f5b8f0f8348a03"
+                    "sha256": "608dc9002b45a91d11ed59e352469ecc05e4f58fc1259fc9a9f5b8f0f8348a03",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 12485,
+                        "stable-only": true,
+                        "url-template": "https://github.com/sass/sassc/archive/$version.tar.gz"
+                    }
                 },
                 {
                     "type": "script",
@@ -45,7 +51,13 @@
                         {
                             "type": "archive",
                             "url": "https://github.com/sass/libsass/archive/3.6.6.tar.gz",
-                            "sha256": "11f0bb3709a4f20285507419d7618f3877a425c0131ea8df40fe6196129df15d"
+                            "sha256": "11f0bb3709a4f20285507419d7618f3877a425c0131ea8df40fe6196129df15d",
+                            "x-checker-data": {
+                                "type": "anitya",
+                                "project-id": 11766,
+                                "stable-only": true,
+                                "url-template": "https://github.com/sass/libsass/archive/$version.tar.gz"
+                            }
                         },
                         {
                             "type": "script",
@@ -68,7 +80,13 @@
                 {
                     "type": "archive",
                     "url": "https://github.com/openrazer/openrazer/releases/download/v3.9.0/openrazer-3.9.0.tar.xz",
-                    "sha256": "273ae58a54645e22ddaf65a627d3fac370328e471e095b735dfa3f0021c7cbeb"
+                    "sha256": "273ae58a54645e22ddaf65a627d3fac370328e471e095b735dfa3f0021c7cbeb",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 243087,
+                        "stable-only": true,
+                        "url-template": "https://github.com/openrazer/openrazer/releases/download/v$version/openrazer-$version.tar.xz"
+                    }
                 }
             ],
             "modules": [
@@ -83,17 +101,32 @@
                         {
                             "type": "file",
                             "url": "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl",
-                            "sha256": "7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2"
+                            "sha256": "7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2",
+                            "x-checker-data": {
+                                "type": "pypi",
+                                "name": "distro",
+                                "packagetype": "bdist_wheel"
+                            }
                         },
                         {
                             "type": "file",
                             "url": "https://files.pythonhosted.org/packages/08/aa/cc0199a5f0ad350994d660967a8efb233fe0416e4639146c089643407ce6/packaging-24.1-py3-none-any.whl",
-                            "sha256": "5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"
+                            "sha256": "5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124",
+                            "x-checker-data": {
+                                "type": "pypi",
+                                "name": "packaging",
+                                "packagetype": "bdist_wheel"
+                            }
                         },
                         {
                             "type": "file",
                             "url": "https://files.pythonhosted.org/packages/c3/a3/21b519f58de90d684056c52ec4e45f744cfda7483f082dcc4dd18cc74a93/scikit_build-0.18.1-py3-none-any.whl",
-                            "sha256": "a6860e300f6807e76f21854163bdb9db16afc74eadf34bd6a9947d3fdfcd725a"
+                            "sha256": "a6860e300f6807e76f21854163bdb9db16afc74eadf34bd6a9947d3fdfcd725a",
+                            "x-checker-data": {
+                                "type": "pypi",
+                                "name": "scikit_build",
+                                "packagetype": "bdist_wheel"
+                            }
                         }
                     ]
                 },
@@ -108,7 +141,11 @@
                         {
                             "type": "file",
                             "url": "https://files.pythonhosted.org/packages/83/ec/ac383eb82792e092d8037649b382cf78a7b79c2ce4e5b861f61519b9b14e/patchelf-0.17.2.1.tar.gz",
-                            "sha256": "a6eb0dd452ce4127d0d5e1eb26515e39186fa609364274bc1b0b77539cfa7031"
+                            "sha256": "a6eb0dd452ce4127d0d5e1eb26515e39186fa609364274bc1b0b77539cfa7031",
+                            "x-checker-data": {
+                                "type": "pypi",
+                                "name": "patchelf"
+                            }
                         }
                     ]
                 },
@@ -123,17 +160,32 @@
                         {
                             "type": "file",
                             "url": "https://files.pythonhosted.org/packages/91/c0/104cb6244c83fe6bc3886f144cc433db0c0c78efac5dc00e409a5a08c87d/meson_python-0.16.0-py3-none-any.whl",
-                            "sha256": "842dc9f5dc29e55fc769ff1b6fe328412fe6c870220fc321060a1d2d395e69e8"
+                            "sha256": "842dc9f5dc29e55fc769ff1b6fe328412fe6c870220fc321060a1d2d395e69e8",
+                            "x-checker-data": {
+                                "type": "pypi",
+                                "name": "meson_python",
+                                "packagetype": "bdist_wheel"
+                            }
                         },
                         {
                             "type": "file",
                             "url": "https://files.pythonhosted.org/packages/08/aa/cc0199a5f0ad350994d660967a8efb233fe0416e4639146c089643407ce6/packaging-24.1-py3-none-any.whl",
-                            "sha256": "5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"
+                            "sha256": "5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124",
+                            "x-checker-data": {
+                                "type": "pypi",
+                                "name": "packaging",
+                                "packagetype": "bdist_wheel"
+                            }
                         },
                         {
                             "type": "file",
                             "url": "https://files.pythonhosted.org/packages/aa/5f/bb5970d3d04173b46c9037109f7f05fc8904ff5be073ee49bb6ff00301bc/pyproject_metadata-0.8.0-py3-none-any.whl",
-                            "sha256": "ad858d448e1d3a1fb408ac5bac9ea7743e7a8bbb472f2693aaa334d2db42f526"
+                            "sha256": "ad858d448e1d3a1fb408ac5bac9ea7743e7a8bbb472f2693aaa334d2db42f526",
+                            "x-checker-data": {
+                                "type": "pypi",
+                                "name": "pyproject_metadata",
+                                "packagetype": "bdist_wheel"
+                            }
                         }
                     ]
                 },
@@ -147,7 +199,11 @@
                         {
                             "type": "archive",
                             "url": "https://files.pythonhosted.org/packages/c1/d3/6be85a9c772d6ebba0cc3ab37390dd6620006dcced758667e0217fb13307/dbus-python-1.3.2.tar.gz",
-                            "sha256": "ad67819308618b5069537be237f8e68ca1c7fcc95ee4a121fe6845b1418248f8"
+                            "sha256": "ad67819308618b5069537be237f8e68ca1c7fcc95ee4a121fe6845b1418248f8",
+                            "x-checker-data": {
+                                "type": "pypi",
+                                "name": "dbus-python"
+                            }
                         },
                         {
                             "type": "patch",

--- a/python3-modules.json
+++ b/python3-modules.json
@@ -78,8 +78,8 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz",
-                    "sha256": "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5",
+                    "url": "https://files.pythonhosted.org/packages/f2/4f/e1808dc01273379acc506d18f1504eb2d299bd4131743b9fc54d7be4df1e/charset_normalizer-3.4.0.tar.gz",
+                    "sha256": "223217c3d4f82c3ac5e29032b3f1c2eb0fb591b72161f86d93f5719079dae93e",
                     "x-checker-data": {
                         "type": "pypi",
                         "name": "charset_normalizer"

--- a/python3-modules.json
+++ b/python3-modules.json
@@ -13,7 +13,11 @@
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/ff/e1/b16b16a1aa12174349d15b73fd4b87e641a8ae3fb1163e80938dbbf6ae98/setproctitle-1.3.3.tar.gz",
-                    "sha256": "c913e151e7ea01567837ff037a23ca8740192880198b7fbb90b16d181607caae"
+                    "sha256": "c913e151e7ea01567837ff037a23ca8740192880198b7fbb90b16d181607caae",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "setproctitle"
+                    }
                 }
             ]
         },
@@ -27,7 +31,12 @@
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl",
-                    "sha256": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+                    "sha256": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "colorama",
+                        "packagetype": "bdist_wheel"
+                    }
                 }
             ]
         },
@@ -41,7 +50,12 @@
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/74/46/e81907704ab203206769dee1385dc77e1407576ff8f50a0681d0a6b541be/colour-0.1.5-py2.py3-none-any.whl",
-                    "sha256": "33f6db9d564fadc16e59921a56999b79571160ce09916303d35346dddc17978c"
+                    "sha256": "33f6db9d564fadc16e59921a56999b79571160ce09916303d35346dddc17978c",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "colour",
+                        "packagetype": "bdist_wheel"
+                    }
                 }
             ]
         },
@@ -55,27 +69,51 @@
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl",
-                    "sha256": "922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8"
+                    "sha256": "922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "certifi",
+                        "packagetype": "bdist_wheel"
+                    }
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz",
-                    "sha256": "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"
+                    "sha256": "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "charset_normalizer"
+                    }
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl",
-                    "sha256": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"
+                    "sha256": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "idna",
+                        "packagetype": "bdist_wheel"
+                    }
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl",
-                    "sha256": "70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"
+                    "sha256": "70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "requests",
+                        "packagetype": "bdist_wheel"
+                    }
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl",
-                    "sha256": "ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac"
+                    "sha256": "ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "urllib3",
+                        "packagetype": "bdist_wheel"
+                    }
                 }
             ]
         }


### PR DESCRIPTION
Ignore the checker data for numpy since the latest nupmy (right now
2.1.2 is not compatible with the cython from the runtime):
```
  Cython compiler for the host machine: cython (cython 0.29.37)
  [...]
  ../meson.build:37:2: ERROR: Problem encountered: NumPy requires Cython >= 3.0.6
```

---

See also https://docs.flathub.org/docs/for-app-authors/external-data-checker